### PR TITLE
パスワードにエスケープ文字があってもログインができるように修正した

### DIFF
--- a/plugin/hatena.vim
+++ b/plugin/hatena.vim
@@ -176,7 +176,7 @@ function! HatenaLogin(user)
         return []
     endif
 
-    let content = system(s:curl_cmd . ' ' . s:hatena_login_url . ' -d name=' . user . ' -d password=' . password . ' -d mode=enter -c "' . cookie_file . '"')
+    let content = system(s:curl_cmd . ' ' . s:hatena_login_url . ' -d name=' . user . ' -d password="' . password . '" -d mode=enter -c "' . cookie_file . '"')
 
     call delete(tmpfile)
 


### PR DESCRIPTION
パスワードにエスケープ文字があってもログインができるように修正しました
現状だと「\」をパスワードに含んでいる場合、「\」を2回連続入力してエスケープしなければログインができませんでしたがpasswordの変数を""で囲むことによってそれを防いでみました
