### PR TITLE
変数g:hatena_no_default_keymappingsを追加しました

### DIFF
--- a/plugin/hatena.vim
+++ b/plugin/hatena.vim
@@ -56,7 +56,10 @@ command! -nargs=? HatenaUpdateTrivial  let b:trivial=1 | call <SID>HatenaUpdate(
 "   :HatenaUser [username]
 command! -nargs=? -complete=customlist,HatenaEnumUsers HatenaUser   if strlen(<q-args>) | let g:hatena_user=<q-args> | else | echo g:hatena_user | endif
 
-nnoremap <Leader>he :HatenaEdit<CR>
+if !exists('g:hatena_no_default_keymappings')
+\   || !g:hatena_no_default_keymappings
+    nnoremap <Leader>he :HatenaEdit<CR>
+endif
 " }}}
 " ===========================
 

--- a/plugin/hatena.vim
+++ b/plugin/hatena.vim
@@ -58,7 +58,7 @@ command! -nargs=? -complete=customlist,HatenaEnumUsers HatenaUser   if strlen(<q
 
 if !exists('g:hatena_no_default_keymappings')
 \   || !g:hatena_no_default_keymappings
-    nnoremap <Leader>he :HatenaEdit<CR>
+    silent! nnoremap <unique> <Leader>he :<C-u>HatenaEdit<CR>
 endif
 " }}}
 " ===========================


### PR DESCRIPTION
変数g:hatena_no_default_keymappingsを追加しました。
もし変数が存在して値が真だったらデフォルトのマッピングを用意しないようにする変数です。

あとデフォルトのマッピングは`<unique>`付きでマッピングするようにしてます。
これによってもしすでに`<Leader>he`がマッピングされてたらエラーが出るようになります。
すでにマッピングがあったらエラーではなく無視(マッピングしないように)してほしいので`:silent!`をつけています。

この2つはたいてい行儀のよいVimプラグインにはあるイディオムみたいなものです。
