### PR TITLE
記事更新した後バッファ削除しない

### DIFF
--- a/plugin/hatena.vim
+++ b/plugin/hatena.vim
@@ -394,7 +394,7 @@ function! s:HatenaUpdate(...) " 更新する
     endif
 
     if &modified
-        noautocmd write
+        noautocmd silent write
     endif
 
     let body_file = expand('%')
@@ -410,14 +410,14 @@ function! HatenaPost(base_url,user,cookie_file,diary,body_file,body_file_enc)
         let body_file=tempname()
         execute 'new '.body_file
         call append(0,a:diary['body'])
-        write
+        silent write
         let &modified=0
         bdelete
     elseif a:body_file ==# expand('%')
         let body_file=a:body_file
         let save_fenc=&fileencoding
         let &fileencoding=a:body_file_enc
-        write
+        silent write
         let &modified=0
     else
         let body_file=a:body_file
@@ -441,7 +441,7 @@ function! HatenaPost(base_url,user,cookie_file,diary,body_file,body_file_enc)
     finally
         if exists('save_fenc')
             let &fileencoding=save_fenc
-            write
+            silent write
             let &modified=0
         endif
     endtry
@@ -478,7 +478,7 @@ function! HatenaPostEntry(login_info, rkm, entry)
         let body_file = a:entry.body_file
         execute 'split ' . body_file
         let &fileencoding = fenc
-        write
+        silent write
         quit
     else
         let body_file = tempname()
@@ -486,7 +486,7 @@ function! HatenaPostEntry(login_info, rkm, entry)
         set paste
         normal! C=a:entry.body
         let &fileencoding = fenc
-        write
+        silent write
         bdelete
     endif
 
@@ -495,7 +495,7 @@ function! HatenaPostEntry(login_info, rkm, entry)
     set paste
     normal! C=a:entry.title
     let &fileencoding = fenc
-    write
+    silent write
     bdelete
 
     let &paste = paste_save

--- a/plugin/hatena.vim
+++ b/plugin/hatena.vim
@@ -287,7 +287,7 @@ function! s:HatenaEdit(...) " 編集する
 
     autocmd BufWritePost <buffer>
     \   if g:hatena_upload_on_write || g:hatena_upload_on_write_bang && v:cmdbang
-    \   | call s:HatenaUpdate() | set readonly |let &titlestring = b:hatena_prev_titlestring | bdelete
+    \   |   call s:HatenaUpdate()
     \   | endif
 
     autocmd WinLeave <buffer> let &titlestring = b:hatena_prev_titlestring
@@ -372,7 +372,7 @@ endfunction
 
 function! s:HatenaUpdate(...) " 更新する
     " 日時を取得
-    if !exists('b:hatena_login_info') || !exists('b:hatena_year') || !exists('b:hatena_month') || !exists('b:hatena_day') || !exists('b:hatena_day_title') || !exists('b:hatena_rkm')
+    if !exists('b:hatena_login_info') || !exists('b:hatena_year') || !exists('b:hatena_month') || !exists('b:hatena_day') || !exists('b:hatena_day_title') || !exists('b:hatena_rkm') || expand('%') == ""
         echoerr ':HatanaEdit してから :HatenaUpdate して下さい'
         return
     endif
@@ -406,14 +406,7 @@ function! s:HatenaUpdate(...) " 更新する
 endfunction
 
 function! HatenaPost(base_url,user,cookie_file,diary,body_file,body_file_enc)
-    if a:body_file == ""
-        let body_file=tempname()
-        execute 'new '.body_file
-        call append(0,a:diary['body'])
-        silent write
-        let &modified=0
-        bdelete
-    elseif a:body_file ==# expand('%')
+    if a:body_file ==# expand('%')
         let body_file=a:body_file
         let save_fenc=&fileencoding
         let &fileencoding=a:body_file_enc

--- a/plugin/hatena.vim
+++ b/plugin/hatena.vim
@@ -112,14 +112,6 @@ if !exists('g:hatena_upload_on_write_bang')
     let g:hatena_upload_on_write_bang = 0
 endif
 
-let s:curl_cmd = 'curl -k --silent'
-if exists('g:chalice_curl_options') " http://d.hatena.ne.jp/smeghead/20070709/hatenavim
-  let s:curl_cmd = s:curl_cmd . ' ' . g:chalice_curl_options
-endif
-let s:hatena_login_url      = 'https://www.hatena.ne.jp/login'
-let s:hatena_base_url       = 'http://d.hatena.ne.jp/'
-let s:hatena_group_base_url = 'http://%s.g.hatena.ne.jp/'
-
 if !exists('g:hatena_upload_on_write')
     let g:hatena_upload_on_write = 1
 endif
@@ -128,6 +120,14 @@ endif
 " " Dropboxに一時ファイルを置くことでDropbox上に履歴を残すことができる
 " let g:hatena_entry_file = '~/Dropbox/memo/blogentry.txt'
 
+
+let s:curl_cmd = 'curl -k --silent'
+if exists('g:chalice_curl_options') " http://d.hatena.ne.jp/smeghead/20070709/hatenavim
+  let s:curl_cmd = s:curl_cmd . ' ' . g:chalice_curl_options
+endif
+let s:hatena_login_url      = 'https://www.hatena.ne.jp/login'
+let s:hatena_base_url       = 'http://d.hatena.ne.jp/'
+let s:hatena_group_base_url = 'http://%s.g.hatena.ne.jp/'
 
 " }}}
 " ===========================


### PR DESCRIPTION
※さっきのtrivial-fixブランチのpull reqの上に作ってます。

`:w`のあとにバッファ削除するのが理由よくわかりませんでした。
また、`:HatenaUpdate`ではバッファ削除しません。
ずっと`:HatenaUpdate`を使って来たのでできれば削除しない方が好みなのですがどうでしょうか...
